### PR TITLE
Add -r and -rd flags for retry count and delay

### DIFF
--- a/etcdexpose.go
+++ b/etcdexpose.go
@@ -39,7 +39,8 @@ var (
 		Key        string
 		Interval   uint
 		Retry      uint
-		RetryDelay uint
+		RetryDelay time.Duration
+		Timeout    time.Duration
 		Ttl        uint64
 		Port       uint
 		CheckPort  uint
@@ -86,8 +87,11 @@ func init() {
 
 	flagset.UintVar(&flags.Retry, "retry", 0, "Healthcheck retry")
 	flagset.UintVar(&flags.Retry, "r", 0, "Healtcheck retry")
-	flagset.UintVar(&flags.RetryDelay, "retry-delay", 5, "Healtcheck retry delay")
-	flagset.UintVar(&flags.RetryDelay, "rd", 5, "Healtcheck retry delay")
+	flagset.DurationVar(&flags.RetryDelay, "retry-delay", 5*time.Second, "Healtcheck retry delay")
+	flagset.DurationVar(&flags.RetryDelay, "rd", 5*time.Second, "Healtcheck retry delay")
+
+	flagset.DurationVar(&flags.Timeout, "client-timeout", 5*time.Second, "Client timeout")
+	flagset.DurationVar(&flags.Timeout, "ct", 5*time.Second, "Client timeout")
 
 	flagset.Uint64Var(&flags.Ttl, "ttl", 0, "Key time to live")
 
@@ -135,6 +139,7 @@ func main() {
 		flags.CheckPort,
 		flags.Retry,
 		flags.RetryDelay,
+		flags.Timeout,
 	)
 
 	namespace_client := etcdexpose.NewEtcdClient(

--- a/etcdexpose.go
+++ b/etcdexpose.go
@@ -25,7 +25,7 @@ import (
 	"github.com/upfluence/etcdexpose/etcdexpose"
 )
 
-const currentVersion = "0.0.9"
+const currentVersion = "0.0.10"
 
 var (
 	flagset = flag.NewFlagSet("etcdexpose", flag.ExitOnError)
@@ -38,6 +38,8 @@ var (
 		HealthPath string
 		Key        string
 		Interval   uint
+		Retry      uint
+		RetryDelay uint
 		Ttl        uint64
 		Port       uint
 		CheckPort  uint
@@ -82,6 +84,11 @@ func init() {
 	flagset.UintVar(&flags.Interval, "interval", 0, "Perform an update at regular interval if > 0")
 	flagset.UintVar(&flags.Interval, "i", 0, "Perform an update at regulat interfal if > 0")
 
+	flagset.UintVar(&flags.Retry, "retry", 0, "Healthcheck retry")
+	flagset.UintVar(&flags.Retry, "r", 0, "Healtcheck retry")
+	flagset.UintVar(&flags.RetryDelay, "retry-delay", 5, "Healtcheck retry delay")
+	flagset.UintVar(&flags.RetryDelay, "rd", 5, "Healtcheck retry delay")
+
 	flagset.Uint64Var(&flags.Ttl, "ttl", 0, "Key time to live")
 
 	flagset.UintVar(&flags.Port, "port", 0, "Port to expose")
@@ -124,7 +131,10 @@ func main() {
 	}
 
 	healthCheck := etcdexpose.NewHealthCheck(
-		flags.HealthPath, flags.CheckPort,
+		flags.HealthPath,
+		flags.CheckPort,
+		flags.Retry,
+		flags.RetryDelay,
 	)
 
 	namespace_client := etcdexpose.NewEtcdClient(

--- a/etcdexpose/healthcheck.go
+++ b/etcdexpose/healthcheck.go
@@ -25,7 +25,10 @@ type urlMembers struct {
 	Port  uint
 }
 
-func NewHealthCheck(path string, port, retry, retryDelay uint) *HealthCheck {
+func NewHealthCheck(
+	path string,
+	port, retry uint,
+	retryDelay, timeout time.Duration) *HealthCheck {
 	tmpl, _ := template.New("url").Parse(URL_TEMPLATE)
 	return &HealthCheck{
 		client:     &http.Client{Timeout: 5 * time.Second},
@@ -33,7 +36,7 @@ func NewHealthCheck(path string, port, retry, retryDelay uint) *HealthCheck {
 		tmpl:       tmpl,
 		port:       port,
 		retry:      retry,
-		retryDelay: time.Duration(retryDelay) * time.Second,
+		retryDelay: retryDelay,
 	}
 }
 

--- a/etcdexpose/multiplevalueexpose.go
+++ b/etcdexpose/multiplevalueexpose.go
@@ -56,7 +56,7 @@ func (m *MultipleValueExpose) Perform() error {
 func (m *MultipleValueExpose) filterNodes(nodes etcd.Nodes) etcd.Nodes {
 	var selection etcd.Nodes
 	for _, node := range nodes {
-		_, err := m.healthCheck.Do(node.Value)
+		err := m.healthCheck.Do(node.Value)
 		if err == nil {
 			log.Printf("Node %s marked as valid", node.Key)
 			selection = append(selection, node)

--- a/etcdexpose/singlevalueexpose.go
+++ b/etcdexpose/singlevalueexpose.go
@@ -54,7 +54,7 @@ func (s *SingleValueExpose) Perform() error {
 func (s *SingleValueExpose) pickNode(nodes etcd.Nodes) *etcd.Node {
 	var pick *etcd.Node = nil
 	for _, node := range nodes {
-		_, err := s.healthCheck.Do(node.Value)
+		err := s.healthCheck.Do(node.Value)
 		if err == nil {
 			pick = node
 			log.Printf(


### PR DESCRIPTION
This deals with https://github.com/upfluence/man/issues/30

It adds a retry mechanism to the healtcheck, avoiding to mark right now a ressource as unavailable

@AlexisMontagne RTM ?
